### PR TITLE
Shorten the resulting HTML

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -19,21 +19,13 @@ module JekyllRedirectFrom
     def generate_redirect_content(item_url)
       self.output = self.content = <<-EOF
       <!DOCTYPE html>
-      <html>
-      <head>
+      <meta charset=utf-8>
       <title>Redirecting...</title>
-      <link rel="canonical" href="#{item_url}"/>
-      <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-      <meta http-equiv="refresh" content="0; url=#{item_url}" />
-      </head>
-      <body>
-        <p><strong>Redirecting...</strong></p>
-        <p><a href='#{item_url}'>Click here if you are not redirected.</a></p>
-        <script>
-          document.location.href = "#{item_url}";
-        </script>
-      </body>
-      </html>
+      <link rel=canonical href="#{item_url}">
+      <meta http-equiv=refresh content="0; url=#{item_url}">
+      <h1>Redirecting...</h1>
+      <a href="#{item_url}">Click here if you are not redirected.</a>
+      <script>location='#{item_url}'</script>
       EOF
     end
   end

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -8,23 +8,23 @@ describe JekyllRedirectFrom::RedirectPage do
 
   context "#generate_redirect_content" do
     it "sets the #content to the generated refresh page" do
-      expect(page_content).to eq("      <!DOCTYPE html>\n      <html>\n      <head>\n      <title>Redirecting...</title>\n      <link rel=\"canonical\" href=\"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\"/>\n      <meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />\n      <meta http-equiv=\"refresh\" content=\"0; url=http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\" />\n      </head>\n      <body>\n        <p><strong>Redirecting...</strong></p>\n        <p><a href='http://jekyllrb.com/2014/01/03/moving-to-jekyll.md'>Click here if you are not redirected.</a></p>\n        <script>\n          document.location.href = \"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\";\n        </script>\n      </body>\n      </html>\n")
+      expect(page_content).to eq("      <!DOCTYPE html>\n      <meta charset=utf-8>\n      <title>Redirecting...</title>\n      <link rel=canonical href=\"#{item_url}\">\n      <meta http-equiv=refresh content=\"0; url=#{item_url}\">\n      <h1>Redirecting...</h1>\n      <a href=\"#{item_url}\">Click here if you are not redirected.</a>\n      <script>location='#{item_url}'</script>\n")
     end
 
     it "contains the meta refresh tag" do
-      expect(page_content).to include("<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\" />")
+      expect(page_content).to include("<meta http-equiv=refresh content=\"0; url=#{item_url}\">")
     end
 
     it "contains JavaScript redirect" do
-      expect(page_content).to include("document.location.href = \"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\";")
+      expect(page_content).to include("location='http://jekyllrb.com/2014/01/03/moving-to-jekyll.md'")
     end
 
     it "contains canonical link in header" do
-      expect(page_content).to include("<link rel=\"canonical\" href=\"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\"/>")
+      expect(page_content).to include("<link rel=canonical href=\"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\">")
     end
 
     it "contains a clickable link to redirect" do
-      expect(page_content).to include("<a href='http://jekyllrb.com/2014/01/03/moving-to-jekyll.md'>Click here if you are not redirected.</a>")
+      expect(page_content).to include("<a href=\"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\">Click here if you are not redirected.</a>")
     end
   end
 


### PR DESCRIPTION
Use shorter charset `<meta>` as per http://mathiasbynens.be/notes/html5-levels#level-1. Also move it to right above the `<title>` as per https://github.com/h5bp/html5-boilerplate/blob/master/doc/html.md#the-order-of-meta-tags-and-title.

I ended up making the HTML response more minimal in general by omitting optional start and end tags, etc. Note that the result is still valid HTML.
