### PR TITLE
Strip out index.html suffix from files that need it

### DIFF
--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -14,7 +14,7 @@ module JekyllRedirectFrom
           alt_urls(item).flatten.each do |alt_url|
             redirect_page = RedirectPage.new(site, site.source, "", "")
             redirect_page.data['permalink'] = alt_url
-            redirect_page.generate_redirect_content(item.url)
+            redirect_page.generate_redirect_content(strip_out_index_html(item.url))
             site.pages << redirect_page
           end
         end
@@ -29,6 +29,10 @@ module JekyllRedirectFrom
 
     def alt_urls(page_or_post)
       Array[page_or_post.data['redirect_from']].flatten
+    end
+
+    def strip_out_index_html(url)
+      url.sub(/\/index\.html?$/, '')
     end
   end
 end


### PR DESCRIPTION
We're thinking about using `jekyll-redirect-from` on https://guides.github.com/. The problem is that our directory structure is something like this:

```
── activities
│   ├── forking
│   │   └── index.md
│   ├── os-contributing
│   │   ├── index.md
│   └── socialize
│       ├── index.md
```

So, if I create a redirect like this:

```
redirect_from: /overviews/socialize
```

The redirect takes me to `activities/socialize/index.html`. I would prefer the clean URL of just `activities/socialize`.

Not sure at all how to test this, or if it's wanted. Let's discuss!
