### PR TITLE
Remove unnecessary 'flatten'

### DIFF
--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -11,7 +11,7 @@ module JekyllRedirectFrom
     def generate_alt_urls(site, list)
       list.each do |item|
         if has_alt_urls?(item)
-          alt_urls(item).flatten.each do |alt_url|
+          alt_urls(item).each do |alt_url|
             redirect_page = RedirectPage.new(site, site.source, "", "")
             redirect_page.data['permalink'] = alt_url
             redirect_page.generate_redirect_content(item.url)


### PR DESCRIPTION
The `alt_urls` method [already calls `flatten`](https://github.com/jekyll/jekyll-redirect-from/blob/a47186219f8f64dd17c27bc2fb264ab4667d0fe9/lib/jekyll-redirect-from/redirector.rb#L39) on its array. Presumably we don't need to call `flatten` again on that return value?

/cc @gjtorikian @parkr
