### PR TITLE
Add support for site.baseurl

### DIFF
--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -14,7 +14,7 @@ module JekyllRedirectFrom
           alt_urls(item).flatten.each do |alt_url|
             redirect_page = RedirectPage.new(site, site.source, "", "")
             redirect_page.data['permalink'] = alt_url
-            redirect_page.generate_redirect_content(item.url)
+            redirect_page.generate_redirect_content("#{site.baseurl}#{item.url}")
             site.pages << redirect_page
           end
         end


### PR DESCRIPTION
I'm _pretty_ sure that this is necessary to generate redirects for sites that specify a `baseurl`. This pull request only addresses `redirect_from` YAML frontmatter—presumably a similar change has to be made for `redirect_to`?

/cc @gjtorikian @parkr
