### PR TITLE
fixed has_alt_urls? and has_redirect_to_url? conditions.

### DIFF
--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -35,23 +35,19 @@ module JekyllRedirectFrom
     end
 
     def has_alt_urls?(page_or_post)
-      page_or_post.data.has_key?('redirect_from') &&
-        !alt_urls(page_or_post).nil? &&
-        !alt_urls(page_or_post).empty?
+      page_or_post.data.has_key?('redirect_from') && !alt_urls(page_or_post).empty?
     end
 
     def alt_urls(page_or_post)
-      Array[page_or_post.data['redirect_from']].flatten
+      Array[page_or_post.data['redirect_from']].flatten.compact
     end
 
     def has_redirect_to_url?(page_or_post)
-      page_or_post.data.has_key?('redirect_to') &&
-        !alt_urls(page_or_post).nil? &&
-        !alt_urls(page_or_post).empty?
+      page_or_post.data.has_key?('redirect_to') && !redirect_to_url(page_or_post).empty?
     end
 
     def redirect_to_url(page_or_post)
-      [Array[page_or_post.data['redirect_to']].flatten.first]
+      [Array[page_or_post.data['redirect_to']].flatten.first].compact
     end
 
     def redirect_url(site, item)


### PR DESCRIPTION
`!alt_urls(page_or_post).empty? && !alt_urls(page_or_post).nil?` were redundant conditions whenever value of `page_or_post.data['redirect_from'] == nil`. In this case `alt_urls = [nil]`
`!alt_urls(page_or_post).nil?`  was redundant because final output of `alt_urls` is always an array

Also, I think `redirect_to_url` should return a single url and not an array, in this way the name would make more sense. If you agree than I could make the necessary changes in the code and resubmit the pull request.
