### PR TITLE
Bump Jekyll dep to 3.0

### DIFF
--- a/jekyll-redirect-from.gemspec
+++ b/jekyll-redirect-from.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jekyll", "~> 2.0"
+  spec.add_runtime_dependency "jekyll", "~> 3.0"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
prepare for jekyll `3.0.0`

tested with jekyll version `3.0.0.pre.beta1` and no apparent problem, i.e.

```
spec.add_runtime_dependency "jekyll", "~> 3.0.0.pre.beta1"
```