### PR TITLE
Minor fix for redirect_to example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Sometimes, you may want to redirect a site page to a totally different website. 
 ```yaml
 title: My amazing post
 redirect_to:
-  - www.github.com
+  - http://www.github.com
 ```
 
 If you have multiple `redirect_to`s set, only the first one will be respected.


### PR DESCRIPTION
There is a little mistake in the redirect_to example in the README: For this to work of course you have to include the protocol in the absolute URL.