### PR TITLE
Exclude redirect pages from sitemap

### DIFF
--- a/jekyll-redirect-from.gemspec
+++ b/jekyll-redirect-from.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "jekyll-sitemap", "~> 0.8.1"
 end

--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -15,14 +15,17 @@ module JekyllRedirectFrom
           alt_urls(item).each do |alt_url|
             redirect_page = RedirectPage.new(site, site.source, "", "")
             redirect_page.data['permalink'] = alt_url
+            redirect_page.data['sitemap'] = false
             redirect_page.generate_redirect_content(redirect_url(site, item))
             site.pages << redirect_page
           end
         end
         if has_redirect_to_url?(item)
           redirect_to_url(item).flatten.each do |alt_url|
+            item.data['sitemap'] = false
             redirect_page = RedirectPage.new(site, site.source, File.dirname(item.url), File.basename(item.url))
             redirect_page.data['permalink'] = item.url
+            redirect_page.data['sitemap'] = false
             redirect_page.generate_redirect_content(alt_url)
             if item.is_a?(Jekyll::Document)
               item.content = item.output = redirect_page.content

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -1,6 +1,7 @@
 url: http://jekyllrb.com
 gems:
   - jekyll-redirect-from
+  - jekyll-sitemap
 collections:
   articles:
     output: true

--- a/spec/jekyll_redirect_from/redirector_spec.rb
+++ b/spec/jekyll_redirect_from/redirector_spec.rb
@@ -38,6 +38,10 @@ describe JekyllRedirectFrom::Redirector do
     expect(redirector.redirect_to_url(page_with_many_redirect_to)).to eql(["https://www.jekyllrb.com"])
   end
 
+  it "does not include pages with a redirect in sitemap" do
+    expect(destination_sitemap).not_to include(%|one_redirect_to.html|)
+  end
+
   context "refresh page generation" do
     before(:each) do
       described_class.new.generate(@site)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,4 +74,8 @@ RSpec.configure do |config|
     page.data['permalink'] = permalink
     page
   end
+
+  def destination_sitemap
+    File.read(File.join(@dest.to_s, 'sitemap.xml'))
+  end
 end


### PR DESCRIPTION
If a page is nothing more than a redirect to another page, it should be excluded from the sitemap.

There are other ways this could be done (like coordinating priority), but I think since we want a specific result it would be best to take specific action.

*Please* look over my code before merging; this is outside of my wheelhouse.

Fixes jekyll/jekyll-sitemap#75