### PR TITLE
Enforce double-quote strings to pass htmlhint

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -19,13 +19,13 @@ module JekyllRedirectFrom
     def generate_redirect_content(item_url)
       self.output = self.content = <<-EOF
 <!DOCTYPE html>
-<meta charset=utf-8>
+<meta charset="utf-8">
 <title>Redirecting...</title>
-<link rel=canonical href="#{item_url}">
-<meta http-equiv=refresh content="0; url=#{item_url}">
+<link rel="canonical" href="#{item_url}">
+<meta http-equiv="refresh" content="0; url=#{item_url}">
 <h1>Redirecting...</h1>
 <a href="#{item_url}">Click here if you are not redirected.</a>
-<script>location='#{item_url}'</script>
+<script>location="#{item_url}"</script>
 EOF
     end
   end

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -8,19 +8,19 @@ describe JekyllRedirectFrom::RedirectPage do
 
   context "#generate_redirect_content" do
     it "sets the #content to the generated refresh page" do
-      expect(page_content).to eq("<!DOCTYPE html>\n<meta charset=utf-8>\n<title>Redirecting...</title>\n<link rel=canonical href=\"#{item_url}\">\n<meta http-equiv=refresh content=\"0; url=#{item_url}\">\n<h1>Redirecting...</h1>\n<a href=\"#{item_url}\">Click here if you are not redirected.</a>\n<script>location='#{item_url}'</script>\n")
+      expect(page_content).to eq("<!DOCTYPE html>\n<meta charset=\"utf-8\">\n<title>Redirecting...</title>\n<link rel=\"canonical\" href=\"#{item_url}\">\n<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\">\n<h1>Redirecting...</h1>\n<a href=\"#{item_url}\">Click here if you are not redirected.</a>\n<script>location=\"#{item_url}\"</script>\n")
     end
 
     it "contains the meta refresh tag" do
-      expect(page_content).to include("<meta http-equiv=refresh content=\"0; url=#{item_url}\">")
+      expect(page_content).to include("<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\">")
     end
 
     it "contains JavaScript redirect" do
-      expect(page_content).to include("location='http://jekyllrb.com/2014/01/03/moving-to-jekyll.md'")
+      expect(page_content).to include("location=\"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\"")
     end
 
     it "contains canonical link in header" do
-      expect(page_content).to include("<link rel=canonical href=\"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\">")
+      expect(page_content).to include("<link rel=\"canonical\" href=\"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\">")
     end
 
     it "contains a clickable link to redirect" do

--- a/spec/jekyll_redirect_from/redirector_spec.rb
+++ b/spec/jekyll_redirect_from/redirector_spec.rb
@@ -68,17 +68,17 @@ describe JekyllRedirectFrom::Redirector do
 
     it "generates the refresh page for the collection with one redirect_to url" do
       expect(@dest.join("articles", "redirect-somewhere-else-plz.html")).to exist
-      expect(destination_doc_contents("articles", "redirect-somewhere-else-plz.html")).to include(%|<meta http-equiv=refresh content="0; url=http://www.zombo.com">|)
+      expect(destination_doc_contents("articles", "redirect-somewhere-else-plz.html")).to include(%|<meta http-equiv="refresh" content="0; url=http://www.zombo.com">|)
     end
 
     it "generates the refresh page for the page with one redirect_to url" do
       expect(destination_file_exists?("one_redirect_to.html")).to be_truthy
-      expect(destination_file_contents("one_redirect_to.html")).to include(%|<meta http-equiv=refresh content="0; url=https://www.github.com">|)
+      expect(destination_file_contents("one_redirect_to.html")).to include(%|<meta http-equiv="refresh" content="0; url=https://www.github.com">|)
     end
 
     it "generates the refresh page for the page with multiple redirect_to urls" do
       expect(destination_file_exists?("multiple_redirect_tos.html")).to be_truthy
-      expect(destination_file_contents("multiple_redirect_tos.html")).to include(%|<meta http-equiv=refresh content="0; url=https://www.jekyllrb.com">|)
+      expect(destination_file_contents("multiple_redirect_tos.html")).to include(%|<meta http-equiv="refresh" content="0; url=https://www.jekyllrb.com">|)
     end
   end
 


### PR DESCRIPTION
The current version of `jekyll-redirect-from` has a combination of single-quote strings and no strings at all. This results in, amongst other things, a filed linting by `htmlhint`. This pull request enforces double quotes.

Continues discussion from <https://github.com/jekyll/jekyll-redirect-from/issues/82>.