### PR TITLE
Stringify all values coming from site.github

### DIFF
--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -74,7 +74,9 @@ module JekyllRedirectFrom
 
     def config_github_url(site)
       github_config = site.config['github']
-      github_config['url'] if github_config.is_a?(Hash)
+      if github_config.is_a?(Hash) && github_config['url']
+        github_config['url'].to_s
+      end
     end
 
     def config_baseurl(site)

--- a/spec/jekyll_redirect_from/redirector_spec.rb
+++ b/spec/jekyll_redirect_from/redirector_spec.rb
@@ -88,6 +88,11 @@ describe JekyllRedirectFrom::Redirector do
       expect(redirector.redirect_url(@site, page_with_one)).to start_with("http://example.github.io/test")
     end
 
+    it "converts non-string values in site.github.url to strings" do
+      @site.config['github'] = { "url" => TestStringContainer.new("http://example.github.io/test") }
+      expect(redirector.redirect_url(@site, page_with_one)).to start_with("http://example.github.io/test")
+    end
+
     it "uses site.baseurl as the redirect prefix when site.github.url is not set" do
       @site.config['baseurl'] = "/fancy/prefix"
       expect(redirector.redirect_url(@site, page_with_one)).to start_with("/fancy/prefix")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -79,3 +79,13 @@ RSpec.configure do |config|
     File.read(File.join(@dest.to_s, 'sitemap.xml'))
   end
 end
+
+class TestStringContainer
+  def initialize(strValue)
+    @val = strValue
+  end
+
+  def to_s
+    @val
+  end
+end


### PR DESCRIPTION
This _should_ convert values to string equivalents when getting them out of `site.github`. See discussion in jekyll/github-metadata#22 for more information.

My two questions:
- Did I successfully do what I had intended to do?
- Should this theoretically fix the issue reported in the linked thread?

@parkr 