### PR TITLE
Improve aesthetics of flash of unstyled content.

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -19,13 +19,17 @@ module JekyllRedirectFrom
     def generate_redirect_content(item_url)
       self.output = self.content = <<-EOF
 <!DOCTYPE html>
+<head>
 <meta charset="utf-8">
-<title>Redirecting...</title>
+<title>Redirecting …</title>
 <link rel="canonical" href="#{item_url}">
 <meta http-equiv="refresh" content="0; url=#{item_url}">
-<h1>Redirecting...</h1>
+</head>
+<body style="font-family: sans-serif">
+<h3>Redirecting …</h3>
 <a href="#{item_url}">Click here if you are not redirected.</a>
 <script>location="#{item_url}"</script>
+</body>
 EOF
     end
   end


### PR DESCRIPTION
This little feature improves the look and feel of the redirect user experience.

A meta refresh with zero seconds delay can still render a 'flash of unstyled content' which can look pretty unprofessional. I'm referring to the huge default serif `<h1>`  that says `Redirecting...`

So, I just added a bit of css: `<body style="font-family: sans-serif">`

and changed the `<h1>` to `<h3>`

Looks much nicer!
