### PR TITLE
Use ellipses instead of three dots

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -1,3 +1,5 @@
+# Encoding: utf-8
+
 module JekyllRedirectFrom
   class RedirectPage < Jekyll::Page
     # Initialize a new RedirectPage.
@@ -20,10 +22,10 @@ module JekyllRedirectFrom
       self.output = self.content = <<-EOF
 <!DOCTYPE html>
 <meta charset="utf-8">
-<title>Redirecting...</title>
+<title>Redirecting…</title>
 <link rel="canonical" href="#{item_url}">
 <meta http-equiv="refresh" content="0; url=#{item_url}">
-<h1>Redirecting...</h1>
+<h1>Redirecting…</h1>
 <a href="#{item_url}">Click here if you are not redirected.</a>
 <script>location="#{item_url}"</script>
 EOF

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -1,3 +1,5 @@
+# Encoding: utf-8
+
 require "spec_helper"
 
 describe JekyllRedirectFrom::RedirectPage do
@@ -8,7 +10,7 @@ describe JekyllRedirectFrom::RedirectPage do
 
   context "#generate_redirect_content" do
     it "sets the #content to the generated refresh page" do
-      expect(page_content).to eq("<!DOCTYPE html>\n<meta charset=\"utf-8\">\n<title>Redirecting...</title>\n<link rel=\"canonical\" href=\"#{item_url}\">\n<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\">\n<h1>Redirecting...</h1>\n<a href=\"#{item_url}\">Click here if you are not redirected.</a>\n<script>location=\"#{item_url}\"</script>\n")
+      expect(page_content).to eq("<!DOCTYPE html>\n<meta charset=\"utf-8\">\n<title>Redirecting…</title>\n<link rel=\"canonical\" href=\"#{item_url}\">\n<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\">\n<h1>Redirecting…</h1>\n<a href=\"#{item_url}\">Click here if you are not redirected.</a>\n<script>location=\"#{item_url}\"</script>\n")
     end
 
     it "contains the meta refresh tag" do


### PR DESCRIPTION
Since the page is served as **utf-8**, I see no reason to use `...` instead of `…`