### PR TITLE
Ensure output extension is assigned

### DIFF
--- a/lib/jekyll-redirect-from.rb
+++ b/lib/jekyll-redirect-from.rb
@@ -1,4 +1,11 @@
 require "jekyll"
+
+module JekyllRedirectFrom
+  def self.jekyll_3?
+    @jekyll_3 ||= (Jekyll::VERSION >= '3.0.0')
+  end
+end
+
 require "jekyll-redirect-from/version"
 require "jekyll-redirect-from/redirect_page"
 require "jekyll-redirect-from/redirector"

--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -16,6 +16,12 @@ module JekyllRedirectFrom
 
       self.process(name)
       self.data = {}
+      
+      data.default_proc = proc do |_, key|
+        site.frontmatter_defaults.find(File.join(dir, name), type, key)
+      end
+      
+      Jekyll::Hooks.trigger :pages, :post_init, self
     end
 
     def generate_redirect_content(item_url)

--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -16,11 +16,11 @@ module JekyllRedirectFrom
 
       self.process(name)
       self.data = {}
-      
+
       data.default_proc = proc do |_, key|
         site.frontmatter_defaults.find(File.join(dir, name), type, key)
       end
-      
+
       Jekyll::Hooks.trigger :pages, :post_init, self
     end
 

--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -21,7 +21,7 @@ module JekyllRedirectFrom
         site.frontmatter_defaults.find(File.join(dir, name), type, key)
       end
 
-      Jekyll::Hooks.trigger :pages, :post_init, self
+      Jekyll::Hooks.trigger :pages, :post_init, self if defined?(Jekyll::Hooks)
     end
 
     def generate_redirect_content(item_url)

--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -21,7 +21,7 @@ module JekyllRedirectFrom
         site.frontmatter_defaults.find(File.join(dir, name), type, key)
       end
 
-      Jekyll::Hooks.trigger :pages, :post_init, self if defined?(Jekyll::Hooks)
+      Jekyll::Hooks.trigger :pages, :post_init, self if JekyllRedirectFrom.jekyll_3?
     end
 
     def generate_redirect_content(item_url)

--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -13,7 +13,7 @@ module JekyllRedirectFrom
       list.each do |item|
         if has_alt_urls?(item)
           alt_urls(item).each do |alt_url|
-            redirect_page = RedirectPage.new(site, site.source, "", "index.html")
+            redirect_page = RedirectPage.new(site, site.source, "", "redirect.html")
             redirect_page.data['permalink'] = alt_url
             redirect_page.data['sitemap'] = false
             redirect_page.generate_redirect_content(redirect_url(site, item))

--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -13,7 +13,7 @@ module JekyllRedirectFrom
       list.each do |item|
         if has_alt_urls?(item)
           alt_urls(item).each do |alt_url|
-            redirect_page = RedirectPage.new(site, site.source, "", "")
+            redirect_page = RedirectPage.new(site, site.source, "", "index.html")
             redirect_page.data['permalink'] = alt_url
             redirect_page.data['sitemap'] = false
             redirect_page.generate_redirect_content(redirect_url(site, item))

--- a/script/test
+++ b/script/test
@@ -1,0 +1,2 @@
+#!/bin/sh
+bundle exec rspec $@

--- a/spec/integrations_spec.rb
+++ b/spec/integrations_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe("Integration Tests") do
   it "writes the redirect pages for collection items which are outputted" do
     expect(dest_dir("articles", "redirect-me-plz.html")).to exist
-    expect(dest_dir("articles", "23128432159832", "mary-had-a-little-lamb.html")).to exist
+    expect(dest_dir("articles", "23128432159832", "mary-had-a-little-lamb#{forced_output_ext}")).to exist
   end
 
   it "doesn't write redirect pages for collection items which are not outputted" do

--- a/spec/integrations_spec.rb
+++ b/spec/integrations_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 describe("Integration Tests") do
   it "writes the redirect pages for collection items which are outputted" do
-    expect(@dest.join("articles", "redirect-me-plz.html")).to exist
-    expect(@dest.join("articles", "23128432159832", "mary-had-a-little-lamb")).to exist
+    expect(dest_dir("articles", "redirect-me-plz.html")).to exist
+    expect(dest_dir("articles", "23128432159832", "mary-had-a-little-lamb.html")).to exist
   end
 
   it "doesn't write redirect pages for collection items which are not outputted" do
-    expect(@dest.join("authors")).not_to exist
-    expect(@dest.join("kansaichris")).not_to exist
+    expect(dest_dir("authors")).not_to exist
+    expect(dest_dir("kansaichris")).not_to exist
   end
 end

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -36,14 +36,14 @@ describe JekyllRedirectFrom::RedirectPage do
       let(:redirect_page) { new_redirect_page(permalink_dir) }
 
       it "knows to add the index.html if it's a folder" do
-        dest = dest_dir("/posts/1914798137981389/larry-had-a-little-lamb/index.html")
+        dest = dest_dir("posts", "1914798137981389", "larry-had-a-little-lamb", "index.html").to_s
         expect(redirect_page.destination("/")).to eql(dest)
       end
     end
 
     context "of a redirect page meant to be a file" do
       it "knows not to add the index.html if it's not a folder" do
-        dest = dest_dir("/posts/12435151125/larry-had-a-little-lamb")
+        dest = dest_dir("posts", "12435151125", "larry-had-a-little-lamb.html").to_s
         expect(redirect_page.destination("/")).to eql(dest)
       end
     end
@@ -58,7 +58,7 @@ describe JekyllRedirectFrom::RedirectPage do
     end
 
     it "fetches the path properly" do
-      expect(redirect_page_full_path).to match /\/spec\/fixtures\/\_site\/posts\/12435151125\/larry-had-a-little-lamb$/
+      expect(redirect_page_full_path).to match /\/spec\/fixtures\/\_site\/posts\/12435151125\/larry-had-a-little-lamb.html$/
     end
 
     it "is written to the proper location" do

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -36,15 +36,19 @@ describe JekyllRedirectFrom::RedirectPage do
       let(:redirect_page) { new_redirect_page(permalink_dir) }
 
       it "knows to add the index.html if it's a folder" do
-        dest = dest_dir("posts", "1914798137981389", "larry-had-a-little-lamb", "index.html").to_s
-        expect(redirect_page.destination("/")).to eql(dest)
+        expected = dest_dir("posts", "1914798137981389", "larry-had-a-little-lamb", "index.html").to_s
+        dest = redirect_page.destination("/")
+        dest = "#{@site.dest}#{dest}" unless dest.start_with? @site.dest
+        expect(dest).to eql(expected)
       end
     end
 
     context "of a redirect page meant to be a file" do
       it "knows not to add the index.html if it's not a folder" do
-        dest = dest_dir("posts", "12435151125", "larry-had-a-little-lamb.html").to_s
-        expect(redirect_page.destination("/")).to eql(dest)
+        expected = dest_dir("posts", "12435151125", "larry-had-a-little-lamb#{forced_output_ext}").to_s
+        dest = redirect_page.destination("/")
+        dest = "#{@site.dest}#{dest}" unless dest.start_with? @site.dest
+        expect(dest).to eql(expected)
       end
     end
   end
@@ -58,7 +62,7 @@ describe JekyllRedirectFrom::RedirectPage do
     end
 
     it "fetches the path properly" do
-      expect(redirect_page_full_path).to match /\/spec\/fixtures\/\_site\/posts\/12435151125\/larry-had-a-little-lamb.html$/
+      expect(redirect_page_full_path).to match /\/spec\/fixtures\/\_site\/posts\/12435151125\/larry-had-a-little-lamb#{forced_output_ext}$/
     end
 
     it "is written to the proper location" do

--- a/spec/jekyll_redirect_from/redirector_spec.rb
+++ b/spec/jekyll_redirect_from/redirector_spec.rb
@@ -52,33 +52,33 @@ describe JekyllRedirectFrom::Redirector do
     end
 
     it "generates the refresh page for the post properly" do
-      expect(destination_file_exists?("posts/23128432159832/mary-had-a-little-lamb")).to be_truthy
+      expect(dest_dir("posts/23128432159832/mary-had-a-little-lamb.html")).to exist
     end
 
     it "generates the refresh pages for the page with multiple redirect_from urls" do
-      expect(destination_file_exists?("help")).to be_truthy
-      expect(destination_file_exists?("contact")).to be_truthy
-      expect(destination_file_exists?("let-there/be/light-he-said")).to be_truthy
-      expect(destination_file_exists?("/geepers/mccreepin")).to be_truthy
+      expect(dest_dir("help")).to be_truthy
+      expect(dest_dir("contact")).to be_truthy
+      expect(dest_dir("let-there/be/light-he-said")).to be_truthy
+      expect(dest_dir("/geepers/mccreepin")).to be_truthy
     end
 
     it "generates the refresh page for the page with one redirect_from url" do
-      expect(destination_file_exists?("mencius/was/my/father")).to be_truthy
+      expect(dest_dir("mencius/was/my/father.html")).to exist
     end
 
     it "generates the refresh page for the collection with one redirect_to url" do
-      expect(@dest.join("articles", "redirect-somewhere-else-plz.html")).to exist
-      expect(destination_doc_contents("articles", "redirect-somewhere-else-plz.html")).to include(%|<meta http-equiv="refresh" content="0; url=http://www.zombo.com">|)
+      expect(dest_dir("articles", "redirect-somewhere-else-plz.html")).to exist
+      expect(dest_dir("articles", "redirect-somewhere-else-plz.html").read).to include(%|<meta http-equiv="refresh" content="0; url=http://www.zombo.com">|)
     end
 
     it "generates the refresh page for the page with one redirect_to url" do
-      expect(destination_file_exists?("one_redirect_to.html")).to be_truthy
-      expect(destination_file_contents("one_redirect_to.html")).to include(%|<meta http-equiv="refresh" content="0; url=https://www.github.com">|)
+      expect(dest_dir("one_redirect_to.html")).to exist
+      expect(dest_dir("one_redirect_to.html").read).to include(%|<meta http-equiv="refresh" content="0; url=https://www.github.com">|)
     end
 
     it "generates the refresh page for the page with multiple redirect_to urls" do
-      expect(destination_file_exists?("multiple_redirect_tos.html")).to be_truthy
-      expect(destination_file_contents("multiple_redirect_tos.html")).to include(%|<meta http-equiv="refresh" content="0; url=https://www.jekyllrb.com">|)
+      expect(dest_dir("multiple_redirect_tos.html")).to exist
+      expect(dest_dir("multiple_redirect_tos.html").read).to include(%|<meta http-equiv="refresh" content="0; url=https://www.jekyllrb.com">|)
     end
   end
 

--- a/spec/jekyll_redirect_from/redirector_spec.rb
+++ b/spec/jekyll_redirect_from/redirector_spec.rb
@@ -11,10 +11,10 @@ describe JekyllRedirectFrom::Redirector do
   let(:page_with_many_redirect_to)  { setup_page("multiple_redirect_tos.md") }
 
   it "knows if a page or post is requesting a redirect page" do
-    if Jekyll::VERSION < '3.0.0'
-      expect(redirector.has_alt_urls?(post_to_redirect)).to be_truthy
-    else
+    if JekyllRedirectFrom.jekyll_3?
       skip "Don't need to test posts in Jekyll 3"
+    else
+      expect(redirector.has_alt_urls?(post_to_redirect)).to be_truthy
     end
   end
 
@@ -52,7 +52,7 @@ describe JekyllRedirectFrom::Redirector do
     end
 
     it "generates the refresh page for the post properly" do
-      expect(dest_dir("posts/23128432159832/mary-had-a-little-lamb.html")).to exist
+      expect(dest_dir("posts/23128432159832/mary-had-a-little-lamb#{forced_output_ext}")).to exist
     end
 
     it "generates the refresh pages for the page with multiple redirect_from urls" do
@@ -63,7 +63,7 @@ describe JekyllRedirectFrom::Redirector do
     end
 
     it "generates the refresh page for the page with one redirect_from url" do
-      expect(dest_dir("mencius/was/my/father.html")).to exist
+      expect(dest_dir("mencius/was/my/father#{forced_output_ext}")).to exist
     end
 
     it "generates the refresh page for the collection with one redirect_to url" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
   end
 
   def dest_dir(*paths)
-    File.join(@dest.to_s, *paths)
+    @dest.join(*paths)
   end
 
   def unpublished_doc
@@ -57,26 +57,15 @@ RSpec.configure do |config|
     Jekyll::Page.new(@site, @fixtures_path.to_s, File.dirname(file), File.basename(file))
   end
 
-  def destination_file_exists?(file)
-    File.exists?(File.join(@dest.to_s, file))
-  end
-
-  def destination_file_contents(file)
-    File.read(File.join(@dest.to_s, file))
-  end
-
-  def destination_doc_contents(collection, file)
-    File.read(File.join(@dest.to_s, collection, file))
-  end
-
   def new_redirect_page(permalink)
-    page = JekyllRedirectFrom::RedirectPage.new(@site, @site.source, "", "")
+    page = JekyllRedirectFrom::RedirectPage.new(@site, @site.source, "", "index.html")
     page.data['permalink'] = permalink
+    page.data['sitemap'] = false
     page
   end
 
   def destination_sitemap
-    File.read(File.join(@dest.to_s, 'sitemap.xml'))
+    @dest.join("sitemap.xml").read
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,10 @@ RSpec.configure do |config|
   def destination_sitemap
     @dest.join("sitemap.xml").read
   end
+
+  def forced_output_ext
+    JekyllRedirectFrom.jekyll_3? ? ".html" : ""
+  end
 end
 
 class TestStringContainer


### PR DESCRIPTION
If you say `redirect_from: "/contact/"`, it'd be `""` because
the permalink had no output_ext _and_ we weren't giving our fake
page any filename so it didn't have an output_ext either.

Narsty :bug: but I think this does it.

/cc @jekyll/plugin-core @benbalter