### PR TITLE
Add <html> tag and language

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -21,6 +21,7 @@ module JekyllRedirectFrom
     def generate_redirect_content(item_url)
       self.output = self.content = <<-EOF
 <!DOCTYPE html>
+<html lang="en-US">
 <meta charset="utf-8">
 <title>Redirecting…</title>
 <link rel="canonical" href="#{item_url}">
@@ -28,6 +29,7 @@ module JekyllRedirectFrom
 <h1>Redirecting…</h1>
 <a href="#{item_url}">Click here if you are not redirected.</a>
 <script>location="#{item_url}"</script>
+</html>
 EOF
     end
   end

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -10,7 +10,7 @@ describe JekyllRedirectFrom::RedirectPage do
 
   context "#generate_redirect_content" do
     it "sets the #content to the generated refresh page" do
-      expect(page_content).to eq("<!DOCTYPE html>\n<meta charset=\"utf-8\">\n<title>Redirecting…</title>\n<link rel=\"canonical\" href=\"#{item_url}\">\n<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\">\n<h1>Redirecting…</h1>\n<a href=\"#{item_url}\">Click here if you are not redirected.</a>\n<script>location=\"#{item_url}\"</script>\n")
+      expect(page_content).to eq("<!DOCTYPE html>\n<html lang=\"en-US\">\n<meta charset=\"utf-8\">\n<title>Redirecting…</title>\n<link rel=\"canonical\" href=\"#{item_url}\">\n<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\">\n<h1>Redirecting…</h1>\n<a href=\"#{item_url}\">Click here if you are not redirected.</a>\n<script>location=\"#{item_url}\"</script>\n</html>\n")
     end
 
     it "contains the meta refresh tag" do


### PR DESCRIPTION
WCAG 2.0, Guideline 3.1.1 requires that

"The default human language of each Web page can be programmatically
determined"

Discovered this while doing an accessibility audit of our Jenkins site and
tripped the
https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_html_01
rule of Google's automated accessibility tool.