### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*
+    - jekyll-redirect-from.gemspec

--- a/History.markdown
+++ b/History.markdown
@@ -31,7 +31,7 @@
 
   * Remove spaces in redirect page (#62)
   * Only parse through documents/pages/posts (#56)
-  * Simplified `has_alt_urls?` and `has_redirect_to_url?` conditions (#52)
+  * Simplified `alt_urls?` and `redirect_to_url?` conditions (#52)
   * Add support for Jekyll 3. (#59)
 
 ## 0.6.2 / 2014-09-12

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require "bundler/gem_tasks"
-require 'rspec/core/rake_task'
+require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 

--- a/jekyll-redirect-from.gemspec
+++ b/jekyll-redirect-from.gemspec
@@ -1,21 +1,21 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-redirect-from/version'
+require "jekyll-redirect-from/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-redirect-from"
   spec.version       = JekyllRedirectFrom::VERSION
   spec.authors       = ["Parker Moore"]
   spec.email         = ["parkrmoore@gmail.com"]
-  spec.description   = %q{Seamlessly specify multiple redirection URLs for your pages and posts}
-  spec.summary       = %q{Seamlessly specify multiple redirection URLs for your pages and posts}
+  spec.description   = "Seamlessly specify multiple redirection URLs for your pages and posts"
+  spec.summary       = "Seamlessly specify multiple redirection URLs for your pages and posts"
   spec.homepage      = "https://github.com/jekyll/jekyll-redirect-from"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($/)
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "jekyll", ">= 2.0"

--- a/lib/jekyll-redirect-from.rb
+++ b/lib/jekyll-redirect-from.rb
@@ -2,7 +2,7 @@ require "jekyll"
 
 module JekyllRedirectFrom
   def self.jekyll_3?
-    @jekyll_3 ||= (Jekyll::VERSION >= '3.0.0')
+    @jekyll_3 ||= (Jekyll::VERSION >= "3.0.0")
   end
 end
 

--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -44,17 +44,15 @@ module JekyllRedirectFrom
         page_or_post.is_a?(Jekyll::Document) ||
         (Jekyll::VERSION < "3.0.0" &&
           page_or_post.is_a?(Jekyll::Post))
-
-      alias :is_dynamic_document? :dynamic_document?
     end
+    alias_method :is_dynamic_document?, :dynamic_document?
 
     def alt_urls?(page_or_post)
       dynamic_document?(page_or_post) &&
         page_or_post.data.key?("redirect_from") &&
         !alt_urls(page_or_post).empty?
-
-      alias :has_alt_urls? :alt_urls?
     end
+    alias_method :has_alt_urls?, :alt_urls?
 
     def alt_urls(page_or_post)
       Array[page_or_post.data["redirect_from"]].flatten.compact

--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -4,66 +4,66 @@ module JekyllRedirectFrom
 
     def generate(site)
       original_pages = site.pages.dup
-      generate_alt_urls(site, site.posts) if Jekyll::VERSION < '3.0.0'
+      generate_alt_urls(site, site.posts) if Jekyll::VERSION < "3.0.0"
       generate_alt_urls(site, original_pages)
       generate_alt_urls(site, site.docs_to_write)
     end
 
     def generate_alt_urls(site, list)
       list.each do |item|
-        if has_alt_urls?(item)
+        if alt_urls?(item)
           alt_urls(item).each do |alt_url|
             redirect_page = RedirectPage.new(site, site.source, "", "redirect.html")
-            redirect_page.data['permalink'] = alt_url
+            redirect_page.data["permalink"] = alt_url
             redirect_page.generate_redirect_content(redirect_url(site, item))
             site.pages << redirect_page
           end
         end
-        if has_redirect_to_url?(item)
-          redirect_to_url(item).flatten.each do |alt_url|
-            item.data['sitemap'] = false
-            item.data['layout'] = nil
+        next unless redirect_to_url?(item)
+        redirect_to_url(item).flatten.each do |alt_url|
+          item.data["sitemap"] = false
+          item.data["layout"] = nil
 
-            item.url << "index.html" if item.url.end_with?("/")
-            redirect_page = RedirectPage.new(site, site.source, File.dirname(item.url), File.basename(item.url))
+          item.url << "index.html" if item.url.end_with?("/")
+          redirect_page = RedirectPage.new(site, site.source,
+                          File.dirname(item.url), File.basename(item.url))
 
-            redirect_page.data['permalink'] = item.url
-            redirect_page.generate_redirect_content(alt_url)
-            if item.is_a?(Jekyll::Document)
-              item.content = item.output = redirect_page.content
-            else
-              site.pages << redirect_page
-            end
+          redirect_page.data["permalink"] = item.url
+          redirect_page.generate_redirect_content(alt_url)
+          if item.is_a?(Jekyll::Document)
+            item.content = item.output = redirect_page.content
+          else
+            site.pages << redirect_page
           end
         end
       end
     end
 
-    def is_dynamic_document?(page_or_post)
+    def dynamic_document?(page_or_post)
       page_or_post.is_a?(Jekyll::Page) ||
         page_or_post.is_a?(Jekyll::Document) ||
-        (Jekyll::VERSION < '3.0.0' &&
+        (Jekyll::VERSION < "3.0.0" &&
           page_or_post.is_a?(Jekyll::Post))
     end
 
-    def has_alt_urls?(page_or_post)
-      is_dynamic_document?(page_or_post) &&
-        page_or_post.data.has_key?('redirect_from') &&
+    def alt_urls?(page_or_post)
+      dynamic_document?(page_or_post) &&
+        page_or_post.data.key?("redirect_from") &&
         !alt_urls(page_or_post).empty?
     end
 
     def alt_urls(page_or_post)
-      Array[page_or_post.data['redirect_from']].flatten.compact
+      Array[page_or_post.data["redirect_from"]].flatten.compact
     end
 
-    def has_redirect_to_url?(page_or_post)
-      is_dynamic_document?(page_or_post) &&
-        page_or_post.data.has_key?('redirect_to') &&
+    def redirect_to_url?(page_or_post)
+      dynamic_document?(page_or_post) &&
+        page_or_post.data.key?("redirect_to") &&
         !redirect_to_url(page_or_post).empty?
     end
 
     def redirect_to_url(page_or_post)
-      [Array[page_or_post.data['redirect_to']].flatten.first].compact
+      [Array[page_or_post.data["redirect_to"]].flatten.first].compact
     end
 
     def redirect_url(site, item)
@@ -75,15 +75,15 @@ module JekyllRedirectFrom
     end
 
     def config_github_url(site)
-      github_config = site.config['github']
-      if github_config.is_a?(Hash) && github_config['url']
-        github_config['url'].to_s
+      github_config = site.config["github"]
+      if github_config.is_a?(Hash) && github_config["url"]
+        github_config["url"].to_s
       end
     end
 
     def config_url(site)
-      url = site.config.fetch('url', nil) || ""
-      baseurl = site.config.fetch('baseurl', nil) || ""
+      url = site.config.fetch("url", nil) || ""
+      baseurl = site.config.fetch("baseurl", nil) || ""
       File.join url, baseurl
     end
   end

--- a/lib/jekyll-redirect-from/redirector.rb
+++ b/lib/jekyll-redirect-from/redirector.rb
@@ -44,12 +44,16 @@ module JekyllRedirectFrom
         page_or_post.is_a?(Jekyll::Document) ||
         (Jekyll::VERSION < "3.0.0" &&
           page_or_post.is_a?(Jekyll::Post))
+
+      alias :is_dynamic_document? :dynamic_document?
     end
 
     def alt_urls?(page_or_post)
       dynamic_document?(page_or_post) &&
         page_or_post.data.key?("redirect_from") &&
         !alt_urls(page_or_post).empty?
+
+      alias :has_alt_urls? :alt_urls?
     end
 
     def alt_urls(page_or_post)

--- a/lib/jekyll-redirect-from/version.rb
+++ b/lib/jekyll-redirect-from/version.rb
@@ -1,3 +1,3 @@
 module JekyllRedirectFrom
-  VERSION = "0.11.0"
+  VERSION = "0.11.0".freeze
 end

--- a/spec/integrations_spec.rb
+++ b/spec/integrations_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe("Integration Tests") do
   it "writes the redirect pages for collection items which are outputted" do

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -62,7 +62,7 @@ describe JekyllRedirectFrom::RedirectPage do
     end
 
     it "fetches the path properly" do
-      expect(redirect_page_full_path).to match /\/spec\/fixtures\/\_site\/posts\/12435151125\/larry-had-a-little-lamb#{forced_output_ext}$/
+      expect(redirect_page_full_path).to match %r!/\/spec\/fixtures\/\_site\/posts\/12435151125\/larry-had-a-little-lamb#{forced_output_ext}$/!
     end
 
     it "is written to the proper location" do

--- a/spec/jekyll_redirect_from/redirector_spec.rb
+++ b/spec/jekyll_redirect_from/redirector_spec.rb
@@ -16,12 +16,12 @@ describe JekyllRedirectFrom::Redirector do
     if JekyllRedirectFrom.jekyll_3?
       skip "Don't need to test posts in Jekyll 3"
     else
-      expect(redirector.has_alt_urls?(post_to_redirect)).to be_truthy
+      expect(redirector.alt_urls?(post_to_redirect)).to be_truthy
     end
   end
 
   it "knows if a document is requesting a redirect page" do
-    expect(redirector.has_alt_urls?(doc_to_redirect_from)).to be_truthy
+    expect(redirector.alt_urls?(doc_to_redirect_from)).to be_truthy
   end
 
   it "knows if a document is requesting a redirect away" do
@@ -49,7 +49,7 @@ describe JekyllRedirectFrom::Redirector do
   end
 
   it "does not include pages with a redirect in sitemap" do
-    expect(destination_sitemap).not_to include(%|one_redirect_to.html|)
+    expect(destination_sitemap).not_to include(%(one_redirect_to.html))
   end
 
   context "refresh page generation" do
@@ -74,75 +74,75 @@ describe JekyllRedirectFrom::Redirector do
 
     it "generates the refresh page for the collection with one redirect_to url" do
       expect(dest_dir("articles", "redirect-somewhere-else-plz.html")).to exist
-      expect(dest_dir("articles", "redirect-somewhere-else-plz.html").read).to include(%|<meta http-equiv="refresh" content="0; url=http://www.zombo.com">|)
+      expect(dest_dir("articles", "redirect-somewhere-else-plz.html").read).to include(%(<meta http-equiv="refresh" content="0; url=http://www.zombo.com">))
     end
 
     it "generates the refresh page for the collection with one redirect_to url and a permalink" do
       expect(dest_dir("tags", "our projects", "index")).not_to exist
       expect(dest_dir("tags", "our projects", "index.html")).to exist
-      expect(dest_dir("tags", "our projects", "index.html").read).to include(%|<meta http-equiv="refresh" content="0; url=/tags/our-projects/">|)
+      expect(dest_dir("tags", "our projects", "index.html").read).to include(%(<meta http-equiv="refresh" content="0; url=/tags/our-projects/">))
     end
 
     it "generates the refresh page for the page with one redirect_to url" do
       expect(dest_dir("one_redirect_to.html")).to exist
-      expect(dest_dir("one_redirect_to.html").read).to include(%|<meta http-equiv="refresh" content="0; url=https://www.github.com">|)
+      expect(dest_dir("one_redirect_to.html").read).to include(%(<meta http-equiv="refresh" content="0; url=https://www.github.com">))
     end
 
     it "generates the refresh page for the page with multiple redirect_to urls" do
       expect(dest_dir("multiple_redirect_tos.html")).to exist
-      expect(dest_dir("multiple_redirect_tos.html").read).to include(%|<meta http-equiv="refresh" content="0; url=https://www.jekyllrb.com">|)
+      expect(dest_dir("multiple_redirect_tos.html").read).to include(%(<meta http-equiv="refresh" content="0; url=https://www.jekyllrb.com">))
     end
 
     it "does not include any default layout" do
       expect(dest_dir("multiple_redirect_tos.html")).to exist
-      expect(dest_dir("multiple_redirect_tos.html").read).not_to include('LAYOUT INCLUDED')
+      expect(dest_dir("multiple_redirect_tos.html").read).not_to include("LAYOUT INCLUDED")
     end
 
     it "generates the refresh page for the page with one redirect_to url and a permalink" do
       expect(dest_dir("tags", "how we work", "index")).not_to exist
       expect(dest_dir("tags", "how we work", "index.html")).to exist
-      expect(dest_dir("tags", "how we work", "index.html").read).to include(%|<meta http-equiv="refresh" content="0; url=/tags/how-we-work/">|)
+      expect(dest_dir("tags", "how we work", "index.html").read).to include(%(<meta http-equiv="refresh" content="0; url=/tags/how-we-work/">))
     end
   end
 
   context "prefix" do
     it "uses site.url as the redirect prefix when site.github.url is not set" do
-      @site.config['url'] = "http://notgithub.io"
-      @site.config['baseurl'] = nil
+      @site.config["url"] = "http://notgithub.io"
+      @site.config["baseurl"] = nil
       expect(redirector.redirect_url(@site, page_with_one)).to eql("http://notgithub.io/one_redirect_url.html")
     end
 
     it "uses site.baseurl as the redirect prefix when site.github.url is not set" do
-      @site.config['url'] = nil
-      @site.config['baseurl'] = "/fancy/prefix"
+      @site.config["url"] = nil
+      @site.config["baseurl"] = "/fancy/prefix"
       expect(redirector.redirect_url(@site, page_with_one)).to eql("/fancy/prefix/one_redirect_url.html")
     end
 
     it "uses site.url + site.baseurl as the redirect prefix when site.github.url is not set" do
-      @site.config['url'] = "http://notgithub.io"
-      @site.config['baseurl'] = "/fancy/prefix"
+      @site.config["url"] = "http://notgithub.io"
+      @site.config["baseurl"] = "/fancy/prefix"
       expect(redirector.redirect_url(@site, page_with_one)).to eql("http://notgithub.io/fancy/prefix/one_redirect_url.html")
     end
 
     it "prefers site.github.url over site.url or site.baseurl" do
-      @site.config['url'] = "http://notgithub.io"
-      @site.config['baseurl'] = "/fancy/prefix"
-      @site.config['github'] = { "url" => "http://example.github.io/test" }
+      @site.config["url"] = "http://notgithub.io"
+      @site.config["baseurl"] = "/fancy/prefix"
+      @site.config["github"] = { "url" => "http://example.github.io/test" }
       expect(redirector.redirect_url(@site, page_with_one)).to eql("http://example.github.io/test/one_redirect_url.html")
     end
 
     it "converts non-string values in site.github.url to strings" do
-      @site.config['github'] = { "url" => TestStringContainer.new("http://example.github.io/test") }
+      @site.config["github"] = { "url" => TestStringContainer.new("http://example.github.io/test") }
       expect(redirector.redirect_url(@site, page_with_one)).to eql("http://example.github.io/test/one_redirect_url.html")
     end
 
     it "uses site.url when site.github is set but site.github.url is not" do
-      @site.config['github'] = "username"
+      @site.config["github"] = "username"
       expect(redirector.redirect_url(@site, page_with_one)).to eql("http://jekyllrb.com/one_redirect_url.html")
     end
 
     it "no-ops when site.github.url and site.baseurl and site.url are not set" do
-      @site.config['url'] = nil
+      @site.config["url"] = nil
       expect(redirector.redirect_url(@site, page_with_one)).to eql("/one_redirect_url.html")
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require File.expand_path("lib/jekyll-redirect-from.rb")
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-  config.order = 'random'
+  config.order = "random"
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
@@ -24,11 +24,11 @@ RSpec.configure do |config|
       "destination" => @dest.to_s,
       "plugins"     => @plugins_src.to_s,
       "collections" => {
-        "articles" => {"output" => true},
+        "articles" => { "output" => true },
         "authors"  => {}
       },
       "defaults"    => [{
-        "scope" => { "path" => "" },
+        "scope"  => { "path" => "" },
         "values" => { "layout" => "layout" }
       }]
     }))
@@ -54,7 +54,7 @@ RSpec.configure do |config|
   end
 
   def setup_post(file)
-    Jekyll::Post.new(@site, @fixtures_path.to_s, '', file)
+    Jekyll::Post.new(@site, @fixtures_path.to_s, "", file)
   end
 
   def setup_page(file)
@@ -63,8 +63,8 @@ RSpec.configure do |config|
 
   def new_redirect_page(permalink)
     page = JekyllRedirectFrom::RedirectPage.new(@site, @site.source, "", "index.html")
-    page.data['permalink'] = permalink
-    page.data['sitemap'] = false
+    page.data["permalink"] = permalink
+    page.data["sitemap"] = false
     page
   end
 
@@ -78,8 +78,8 @@ RSpec.configure do |config|
 end
 
 class TestStringContainer
-  def initialize(strValue)
-    @val = strValue
+  def initialize(str_value)
+    @val = str_value
   end
 
   def to_s


### PR DESCRIPTION
This PR is the result of adding inherit_gem:\n jekyll: .rubocop.yml to .rubocop.yml and running rubocop -a so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.
