### PR TITLE
Preserve search and hash in redirect

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -31,10 +31,19 @@ module JekyllRedirectFrom
 <meta charset="utf-8">
 <title>Redirecting…</title>
 <link rel="canonical" href="#{item_url}">
-<meta http-equiv="refresh" content="0; url=#{item_url}">
+<meta http-equiv="refresh" content="1; url=#{item_url}">
 <h1>Redirecting…</h1>
 <a href="#{item_url}">Click here if you are not redirected.</a>
-<script>location="#{item_url}"</script>
+<script>
+  var url = '#{item_url}';
+  if (location.search && url.indexOf('?') === -1) {
+    url = url.replace(/($|#)/, location.search + '$1');
+  }
+  if (location.hash && url.indexOf('#') === -1) {
+    url += location.hash; 
+  }
+  location=url;
+</script>
 </html>
 EOF
     end

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -10,15 +10,19 @@ describe JekyllRedirectFrom::RedirectPage do
 
   context "#generate_redirect_content" do
     it "sets the #content to the generated refresh page" do
-      expect(page_content).to eq("<!DOCTYPE html>\n<html lang=\"en-US\">\n<meta charset=\"utf-8\">\n<title>Redirecting…</title>\n<link rel=\"canonical\" href=\"#{item_url}\">\n<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\">\n<h1>Redirecting…</h1>\n<a href=\"#{item_url}\">Click here if you are not redirected.</a>\n<script>location=\"#{item_url}\"</script>\n</html>\n")
+      expect(page_content).to eq("<!DOCTYPE html>\n<html lang=\"en-US\">\n<meta charset=\"utf-8\">\n<title>Redirecting…</title>\n<link rel=\"canonical\" href=\"#{item_url}\">\n<meta http-equiv=\"refresh\" content=\"1; url=#{item_url}\">\n<h1>Redirecting…</h1>\n<a href=\"#{item_url}\">Click here if you are not redirected.</a>\n<script>\n  var url = '#{item_url}';\n  if (location.search && url.indexOf('?') === -1) {\n    url = url.replace(/($|#)/, location.search + '$1');\n  }\n  if (location.hash && url.indexOf('#') === -1) {\n    url += location.hash; \n  }\n  location=url;\n</script>\n</html>\n")
     end
 
     it "contains the meta refresh tag" do
-      expect(page_content).to include("<meta http-equiv=\"refresh\" content=\"0; url=#{item_url}\">")
+      expect(page_content).to include("<meta http-equiv=\"refresh\" content=\"1; url=#{item_url}\">")
+    end
+
+    it "contains the url" do
+      expect(page_content).to include("var url = 'http://jekyllrb.com/2014/01/03/moving-to-jekyll.md';")
     end
 
     it "contains JavaScript redirect" do
-      expect(page_content).to include("location=\"http://jekyllrb.com/2014/01/03/moving-to-jekyll.md\"")
+      expect(page_content).to include("location=url;")
     end
 
     it "contains canonical link in header" do

--- a/spec/jekyll_redirect_from/redirector_spec.rb
+++ b/spec/jekyll_redirect_from/redirector_spec.rb
@@ -74,23 +74,23 @@ describe JekyllRedirectFrom::Redirector do
 
     it "generates the refresh page for the collection with one redirect_to url" do
       expect(dest_dir("articles", "redirect-somewhere-else-plz.html")).to exist
-      expect(dest_dir("articles", "redirect-somewhere-else-plz.html").read).to include(%|<meta http-equiv="refresh" content="0; url=http://www.zombo.com">|)
+      expect(dest_dir("articles", "redirect-somewhere-else-plz.html").read).to include(%|<meta http-equiv="refresh" content="1; url=http://www.zombo.com">|)
     end
 
     it "generates the refresh page for the collection with one redirect_to url and a permalink" do
       expect(dest_dir("tags", "our projects", "index")).not_to exist
       expect(dest_dir("tags", "our projects", "index.html")).to exist
-      expect(dest_dir("tags", "our projects", "index.html").read).to include(%|<meta http-equiv="refresh" content="0; url=/tags/our-projects/">|)
+      expect(dest_dir("tags", "our projects", "index.html").read).to include(%|<meta http-equiv="refresh" content="1; url=/tags/our-projects/">|)
     end
 
     it "generates the refresh page for the page with one redirect_to url" do
       expect(dest_dir("one_redirect_to.html")).to exist
-      expect(dest_dir("one_redirect_to.html").read).to include(%|<meta http-equiv="refresh" content="0; url=https://www.github.com">|)
+      expect(dest_dir("one_redirect_to.html").read).to include(%|<meta http-equiv="refresh" content="1; url=https://www.github.com">|)
     end
 
     it "generates the refresh page for the page with multiple redirect_to urls" do
       expect(dest_dir("multiple_redirect_tos.html")).to exist
-      expect(dest_dir("multiple_redirect_tos.html").read).to include(%|<meta http-equiv="refresh" content="0; url=https://www.jekyllrb.com">|)
+      expect(dest_dir("multiple_redirect_tos.html").read).to include(%|<meta http-equiv="refresh" content="1; url=https://www.jekyllrb.com">|)
     end
 
     it "does not include any default layout" do
@@ -101,7 +101,7 @@ describe JekyllRedirectFrom::Redirector do
     it "generates the refresh page for the page with one redirect_to url and a permalink" do
       expect(dest_dir("tags", "how we work", "index")).not_to exist
       expect(dest_dir("tags", "how we work", "index.html")).to exist
-      expect(dest_dir("tags", "how we work", "index.html").read).to include(%|<meta http-equiv="refresh" content="0; url=/tags/how-we-work/">|)
+      expect(dest_dir("tags", "how we work", "index.html").read).to include(%|<meta http-equiv="refresh" content="1; url=/tags/how-we-work/">|)
     end
   end
 


### PR DESCRIPTION
Closes #123

- Delays meta refresh with 1s to give JavaScript time to update it
- Update meta refresh and link (canonical doesn't make any sense AFAIK) with search and hash
- Use search and hash in scripted redirect