### PR TITLE
set `page.output` to empty string instead of nil

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -33,7 +33,7 @@ module JekyllRedirectFrom
 
     # Overwrite the default read_yaml method since the file doesn't exist
     def read_yaml(_base, _name, _opts = {})
-      self.content = ""
+      self.content = self.output = ""
       self.data ||= DEFAULT_DATA.dup
     end
 

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -14,6 +14,10 @@ describe JekyllRedirectFrom::RedirectPage do
       expect(subject.content).to eql("")
     end
 
+    it "returns no output" do
+      expect(subject.output).to eql("")
+    end
+
     it "sets default data" do
       expect(subject.to_liquid["layout"]).to eql("redirect")
       expect(subject.to_liquid["sitemap"]).to be_falsey


### PR DESCRIPTION
The output of the redirect page is [used to initialize the content and output of the doc](https://github.com/jekyll/jekyll-redirect-from/blame/b93e81cc7d585c75fcbef1cf64131dbf166f0bf4/lib/jekyll-redirect-from/generator.rb#L35). Before this patch this was `nil` which raised an exception when [`gsub` was called on it.](https://github.com/jch/html-pipeline/blob/6d223dc2f7e7f307d3bda8902e225c0d5ea0b2e8/lib/html/pipeline/emoji_filter.rb#L46)

fixes jekyll/jekyll#5755