### PR TITLE
Make redirect.html pass HTML validation.

### DIFF
--- a/lib/jekyll-redirect-from/redirect.html
+++ b/lib/jekyll-redirect-from/redirect.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
 <html lang="en-US">
-  <meta charset="utf-8">
-  <title>Redirecting…</title>
-  <link rel="canonical" href="{{ page.redirect.to }}">
-  <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
-  <h1>Redirecting…</h1>
-  <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
-  <script>location="{{ page.redirect.to }}"</script>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirecting…</title>
+    <link rel="canonical" href="{{ page.redirect.to }}">
+    <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  </head>
+  <body>
+    <h1>Redirecting…</h1>
+    <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+    <script>location="{{ page.redirect.to }}"</script>
+  </body>
 </html>


### PR DESCRIPTION
I'm half expecting this to be rejected, but maybe it will be considered. The lack of `<head>` and `<body>` causes issues with projects that lint their generated documentation with something like htmllint.