### PR TITLE
Create redirects.json file

### DIFF
--- a/lib/jekyll-redirect-from.rb
+++ b/lib/jekyll-redirect-from.rb
@@ -6,10 +6,11 @@ module JekyllRedirectFrom
   # Jekyll classes which should be redirectable
   CLASSES = [Jekyll::Page, Jekyll::Document].freeze
 
-  autoload :Context,      "jekyll-redirect-from/context"
-  autoload :RedirectPage, "jekyll-redirect-from/redirect_page"
-  autoload :Redirectable, "jekyll-redirect-from/redirectable"
-  autoload :Layout,       "jekyll-redirect-from/layout"
+  autoload :Context,          "jekyll-redirect-from/context"
+  autoload :RedirectPage,     "jekyll-redirect-from/redirect_page"
+  autoload :Redirectable,     "jekyll-redirect-from/redirectable"
+  autoload :Layout,           "jekyll-redirect-from/layout"
+  autoload :PageWithoutAFile, "jekyll-redirect-from/page_without_a_file"
 end
 
 JekyllRedirectFrom::CLASSES.each do |klass|

--- a/lib/jekyll-redirect-from/page_without_a_file.rb
+++ b/lib/jekyll-redirect-from/page_without_a_file.rb
@@ -1,0 +1,7 @@
+module JekyllRedirectFrom
+  class PageWithoutAFile < Jekyll::Page
+    def read_yaml(*)
+      @data ||= {}
+    end
+  end
+end

--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -52,6 +52,14 @@ module JekyllRedirectFrom
       })
     end
 
+    def redirect_from
+      data["redirect"]["from"] if data["redirect"]
+    end
+
+    def redirect_to
+      data["redirect"]["to"] if data["redirect"]
+    end
+
     private
 
     def context

--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -43,6 +43,7 @@ module JekyllRedirectFrom
     # to   - the relative path or absolute URL to the redirect target
     def set_paths(from, to)
       @context ||= context
+      from = ensure_leading_slash(from)
       data.merge!({
         "permalink" => from,
         "redirect"  => {

--- a/spec/jekyll_redirect_from/generator_spec.rb
+++ b/spec/jekyll_redirect_from/generator_spec.rb
@@ -111,16 +111,16 @@ RSpec.describe JekyllRedirectFrom::Generator do
     end
 
     it "contains single redirect froms" do
-      expect(redirects.keys).to include "some/other/path"
-      expect(redirects["some/other/path"]).to eql("#{domain}/one_redirect_from.html")
+      expect(redirects.keys).to include "/some/other/path"
+      expect(redirects["/some/other/path"]).to eql("#{domain}/one_redirect_from.html")
     end
 
     it "contains multiple redirect froms" do
-      expect(redirects.keys).to include "help"
-      expect(redirects["help"]).to eql("#{domain}/multiple_redirect_froms.html")
+      expect(redirects.keys).to include "/help"
+      expect(redirects["/help"]).to eql("#{domain}/multiple_redirect_froms.html")
 
-      expect(redirects.keys).to include "contact"
-      expect(redirects["contact"]).to eql("#{domain}/multiple_redirect_froms.html")
+      expect(redirects.keys).to include "/contact"
+      expect(redirects["/contact"]).to eql("#{domain}/multiple_redirect_froms.html")
     end
 
     context "with a user-supplied redirects.json" do

--- a/spec/jekyll_redirect_from/generator_spec.rb
+++ b/spec/jekyll_redirect_from/generator_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe JekyllRedirectFrom::Generator do
     site.read
     site.generate
     site.render
+    site.write
   end
 
   context "layouts" do
@@ -81,6 +82,65 @@ RSpec.describe JekyllRedirectFrom::Generator do
 
       it "redirects" do
         expect(doc.output).to match("http://www.zombo.com")
+      end
+    end
+  end
+
+  context "redirects.json" do
+    let(:path) { dest_dir("redirects.json") }
+    let(:contents) { File.read(path) }
+    let(:redirects) { JSON.parse(contents) }
+    let(:domain) { "http://jekyllrb.com" }
+
+    it "creates the redirets file" do
+      expect(path).to exist
+    end
+
+    it "contains redirects" do
+      expect(redirects.count).to eql(13)
+    end
+
+    it "contains single redirects tos" do
+      expect(redirects.keys).to include "/one_redirect_to_path.html"
+      expect(redirects["/one_redirect_to_path.html"]).to eql("#{domain}/foo")
+    end
+
+    it "contains multiple redirect tos" do
+      expect(redirects.keys).to include "/multiple_redirect_tos.html"
+      expect(redirects["/multiple_redirect_tos.html"]).to eql("https://www.jekyllrb.com")
+    end
+
+    it "contains single redirect froms" do
+      expect(redirects.keys).to include "some/other/path"
+      expect(redirects["some/other/path"]).to eql("#{domain}/one_redirect_from.html")
+    end
+
+    it "contains multiple redirect froms" do
+      expect(redirects.keys).to include "help"
+      expect(redirects["help"]).to eql("#{domain}/multiple_redirect_froms.html")
+
+      expect(redirects.keys).to include "contact"
+      expect(redirects["contact"]).to eql("#{domain}/multiple_redirect_froms.html")
+    end
+
+    context "with a user-supplied redirects.json" do
+      let(:source_path) { File.join fixtures_path, "redirects.json" }
+      before do
+        File.write source_path, { "foo" => "bar" }.to_json
+        site.reset
+        site.read
+        site.generate
+        site.render
+        site.write
+      end
+
+      after do
+        FileUtils.rm_f source_path
+      end
+
+      it "doesn't overwrite redirets.json" do
+        expect(path).to exist
+        expect(redirects).to eql({ "foo" => "bar" })
       end
     end
   end


### PR DESCRIPTION
Since https://github.com/jekyll/jekyll-redirect-from/pull/131, https://github.com/jekyll/jekyll-redirect-from/issues/125 is much easier to implement and this PR does just that.

At build time, if the site source does not have a `redirects.json` file, the the plugin will add a `redirects.json` file with a hash in the format of `from_path => to_url`.

Here's an example of what the specs look like:

```json
{  
   "/posts/23128432159832/mary-had-a-little-lamb":"http://jekyllrb.com/2014/01/03/redirect-me-plz.html",
   "/articles/23128432159832/mary-had-a-little-lamb":"http://jekyllrb.com/articles/redirect-me-plz.html",
   "/tags/our projects/":"http://jekyllrb.com/tags/our-projects/",
   "/articles/redirect-somewhere-else-plz.html":"http://www.zombo.com",
   "/tags/how we work/":"http://jekyllrb.com/tags/how-we-work/",
   "help":"http://jekyllrb.com/multiple_redirect_froms.html",
   "contact":"http://jekyllrb.com/multiple_redirect_froms.html",
   "let-there/be/light-he-said":"http://jekyllrb.com/multiple_redirect_froms.html",
   "/geepers/mccreepin":"http://jekyllrb.com/multiple_redirect_froms.html",
   "/multiple_redirect_tos.html":"https://www.jekyllrb.com",
   "some/other/path":"http://jekyllrb.com/one_redirect_from.html",
   "/one_redirect_to_path.html":"http://jekyllrb.com/foo",
   "/one_redirect_to_url.html":"https://www.github.com"
}
```

This could theoretically be used for automated testing, or to implement server-side redirects.

Thoughts?