### PR TITLE
Added no-index

### DIFF
--- a/lib/jekyll-redirect-from/redirect.html
+++ b/lib/jekyll-redirect-from/redirect.html
@@ -4,6 +4,7 @@
   <title>Redirecting&hellip;</title>
   <link rel="canonical" href="{{ page.redirect.to }}">
   <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
+  <meta name="robots" content="noindex">
   <h1>Redirecting…</h1>
   <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
   <script>location="{{ page.redirect.to }}"</script>


### PR DESCRIPTION
Search bots will want to index the canonical page not the redirect one, tell them to ignore this page (but still follow the link)