### PR TITLE
Fix remaining ellipsis in redirect.html

### DIFF
--- a/lib/jekyll-redirect-from/redirect.html
+++ b/lib/jekyll-redirect-from/redirect.html
@@ -5,7 +5,7 @@
   <link rel="canonical" href="{{ page.redirect.to }}">
   <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
   <meta name="robots" content="noindex">
-  <h1>Redirecting…</h1>
+  <h1>Redirecting&hellip;</h1>
   <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
   <script>location="{{ page.redirect.to }}"</script>
 </html>


### PR DESCRIPTION
Hi! It seems #142 fixed the horizontal ellipsis in the `<title>` but not the body.

I was still experiencing #139, but this edit fixed it for me.
