### PR TITLE
Correct double slash from to and from URLs

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -44,7 +44,8 @@ module JekyllRedirectFrom
     # to   - the relative path or absolute URL to the redirect target
     def set_paths(from, to)
       @context ||= context
-      from = ensure_leading_slash(from)
+      from = ensure_leading_slash(correct_double_slash(from))
+      to = correct_double_slash(to)
       data.merge!({
         "permalink" => from,
         "redirect"  => {
@@ -66,6 +67,10 @@ module JekyllRedirectFrom
 
     def context
       JekyllRedirectFrom::Context.new(site)
+    end
+
+    def correct_double_slash(path_or_url)
+      path_or_url.gsub(%r{(?<!:)/{2,}}){'/'}
     end
   end
 end

--- a/spec/fixtures/double_slash_redirect_to_url.md
+++ b/spec/fixtures/double_slash_redirect_to_url.md
@@ -1,0 +1,8 @@
+---
+title: I have multiple slashes in the URL
+redirect_to:
+- http://example.com//ggg/hhh/iii///
+
+---
+
+Redirects with double slashes

--- a/spec/fixtures/multiple_redirect_froms.md
+++ b/spec/fixtures/multiple_redirect_froms.md
@@ -5,6 +5,7 @@ redirect_from:
 - contact
 - let-there/be/light-he-said
 - /geepers/mccreepin
+- //I/have///multiple/slashes
 ---
 
 Lots of redirect urls

--- a/spec/integrations_spec.rb
+++ b/spec/integrations_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "JekyllRedirectFrom integration tests" do
     end
 
     context "multiple redirect froms" do
-      %w(help contact let-there/be/light-he-said geepers/mccreepin).each do |redirect|
+      %w(help contact let-there/be/light-he-said geepers/mccreepin I/have/multiple/slashes).each do |redirect|
         context "the #{redirect} redirect" do
           let(:relative_path) { "#{redirect}.html" }
 
@@ -42,6 +42,15 @@ RSpec.describe "JekyllRedirectFrom integration tests" do
       it "exists in the built site" do
         expect(path).to exist
         expect(contents).to match("http://jekyllrb.com/foo")
+      end
+    end
+
+    context "redirect to URL with double slash" do
+      let(:relative_path) { "double_slash_redirect_to_url.html" }
+
+      it "exists in the built site" do
+        expect(path).to exist
+        expect(contents).to match("http://example.com/ggg/hhh/iii/")
       end
     end
   end


### PR DESCRIPTION
This was happening in a setup I have with
baseurl: /

and an en/index.md file with
redirect_from: /

which creates an /index.html with the redirection:
http://localhost:4000//en/

this corrects it to
http://localhost:4000/en/