### PR TITLE
run javascript at first to avoid splash

### DIFF
--- a/lib/jekyll-redirect-from/redirect.html
+++ b/lib/jekyll-redirect-from/redirect.html
@@ -3,9 +3,9 @@
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
   <link rel="canonical" href="{{ page.redirect.to }}">
+  <script>location="{{ page.redirect.to }}"</script>
   <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
   <meta name="robots" content="noindex">
   <h1>Redirecting&hellip;</h1>
   <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
-  <script>location="{{ page.redirect.to }}"</script>
 </html>


### PR DESCRIPTION
Just changed the order of the scripts.
In most browsers (such as chrome), it will execute the javascript before page rendering.
So that the page will redirect without the splash white screen :)