### PR TITLE
Fix tests for jekyll 3.5.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,9 @@ matrix:
     - # GitHub Pages
       rvm: 2.4.0
       env: GH_PAGES=true
-  allow_failures:
-    - env: GH_PAGES=true # Jekyll 2.4 will fail tests
-  fast_finish: true
 
 rvm:
-  - 2.3.0
+  - 2.4
+  - 2.3
   - 2.2
   - 2.1
-  - 2.0

--- a/jekyll-redirect-from.gemspec
+++ b/jekyll-redirect-from.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec", "~> 3.5"
   spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "jekyll-sitemap", "~> 0.8.1"
+  spec.add_development_dependency "jekyll-sitemap", "~> 1.0"
   spec.add_development_dependency "rubocop", "~> 0.43"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,7 +48,7 @@ RSpec.configure do |config|
         "scope"  => { "path" => "" },
         "values" => { "layout" => "layout" },
       },],
-    })
+    }).backwards_compatibilize
   end
 
   def site


### PR DESCRIPTION
This allows us to use the `gems` key to init jekyll-sitemap for pre 3.5, but also work for 3.5+.