### PR TITLE
Render liquid tags in redirect urls.

### DIFF
--- a/lib/jekyll-redirect-from/redirect_page.rb
+++ b/lib/jekyll-redirect-from/redirect_page.rb
@@ -17,6 +17,8 @@ module JekyllRedirectFrom
     # from - the (URL) path, relative to the site root to redirect from
     # to   - the relative path or URL which the page should redirect to
     def self.from_paths(site, from, to)
+      from = Liquid::Template.parse(from).render("site" => site.config)
+      to = Liquid::Template.parse(to).render("site" => site.config)
       page = RedirectPage.new(site, site.source, "", "redirect.html")
       page.set_paths(from, to)
       page

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -92,6 +92,15 @@ describe JekyllRedirectFrom::RedirectPage do
             expect(page.to_liquid["redirect"]["from"]).to eql("/2014/01/03/redirect-me-plz.html")
           end
         end
+
+        context "redirecting to a URL with liquid tags" do
+          let(:to) { "https://{{site.remote_app}}/login" }
+          let(:site) { Jekyll::Site.new(config.merge("remote_app" => "example.org")) }
+
+          it "redirects with liquid tags rendered" do
+            expect(page.to_liquid["redirect"]["to"]).to eql("https://example.org/login")
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This change allows `to` urls to include liquid tags, this used to work in v0.10.0 I believe. 