### PR TITLE
Allow testing and using with Jekyll 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: ruby
 cache: bundler
+rvm:
+  - &latest_ruby 2.6
+  - 2.4
+  - 2.3
+env:
+  - JEKYLL_VERSION="~> 3.8"
 matrix:
   include:
     - # GitHub Pages
       rvm: 2.5.3
       env: GH_PAGES=true
-rvm:
-  - 2.6
-  - 2.4
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+
 before_install:
 - gem update --system
 before_script: bundle update

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "github-pages" if ENV["GH_PAGES"]
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]

--- a/jekyll-redirect-from.gemspec
+++ b/jekyll-redirect-from.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency "jekyll", "~> 3.3"
+  spec.add_runtime_dependency "jekyll", ">= 3.3", "< 5.0"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "jekyll-sitemap", "~> 1.0"
   spec.add_development_dependency "rake", "~> 12.0"


### PR DESCRIPTION
Minimal changes to allow testing with Jekyll 4.0 pre-release.