### PR TITLE
Stop testing with backwards-compatible site config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       rvm: 2.5.3
       env: GH_PAGES=true
     - rvm: *latest_ruby
-      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+      env: JEKYLL_VERSION="~> 4.0"
 
 before_install:
 - gem update --system

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,7 +42,7 @@ RSpec.configure do |config|
         "authors"  => {},
       },
       "url"         => "http://jekyllrb.com",
-      "gems"        => [
+      "plugins"     => [
         "jekyll-redirect-from",
         "jekyll-sitemap",
       ],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,7 +50,7 @@ RSpec.configure do |config|
         "scope"  => { "path" => "" },
         "values" => { "layout" => "layout" },
       }]
-    ).backwards_compatibilize
+    )
   end
 
   def site


### PR DESCRIPTION
So that tests do not fail when using Jekyll 4.0