### PR TITLE
Refactor specs for RedirectPage

### DIFF
--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -1,78 +1,78 @@
 # frozen_string_literal: true
 
-shared_examples 'a redirect page' do
-  context "being a page" do
-    before { subject.read_yaml(nil, nil, nil) }
-
-    it "returns no content" do
-      expect(subject.content).to eql("")
-    end
-
-    it "returns no output" do
-      expect(subject.output).to eql("")
-    end
-
-    it "sets default data" do
-      expect(subject.to_liquid["layout"]).to eql("redirect")
-      expect(subject.to_liquid["sitemap"]).to be_falsey
-    end
-
-    it "sets the paths" do
-      expect(subject.to_liquid["permalink"]).to eql(from)
-      expect(subject.to_liquid).to have_key("redirect")
-      expect(subject.to_liquid["redirect"]["from"]).to eql(from)
-      expect(subject.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
-    end
-
-    it "sets the permalink" do
-      expect(subject.to_liquid["permalink"]).to eql(from)
-    end
-
-    it "sets redirect metadata" do
-      expect(subject.to_liquid).to have_key("redirect")
-      expect(subject.to_liquid["redirect"]["from"]).to eql(from)
-      expect(subject.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
-    end
-  end
-
-  context "generating" do
-    before { site.generate }
-    let(:output) { Jekyll::Renderer.new(site, subject, site.site_payload).run }
-
-    it "renders the template" do
-      expect(output).to_not be_nil
-      expect(output.to_s).to_not be_empty
-    end
-
-    it "contains the meta refresh tag" do
-      expect(output).to match("<meta http-equiv=\"refresh\" content=\"0; url=#{site_url}#{to}\">")
-    end
-
-    it "contains the javascript redirect" do
-      expect(output).to match("<script>location=\"#{site_url}#{to}\"</script>")
-    end
-
-    it "contains canonical link in header" do
-      expect(output).to match("<link rel=\"canonical\" href=\"#{site_url}#{to}\">")
-    end
-
-    it "contains the clickable link" do
-      expect(output).to match("<a href=\"#{site_url}#{to}\">Click here if you are not redirected.</a>")
-    end
-  end
-end
-
 describe JekyllRedirectFrom::RedirectPage do
   let(:site_url) { site.config["url"] }
   before { site.read }
 
-  describe 'redirecting to' do
+  shared_examples "a redirect page" do
+    context "being a page" do
+      before { subject.read_yaml(nil, nil, nil) }
+
+      it "returns no content" do
+        expect(subject.content).to eql("")
+      end
+
+      it "returns no output" do
+        expect(subject.output).to eql("")
+      end
+
+      it "sets default data" do
+        expect(subject.to_liquid["layout"]).to eql("redirect")
+        expect(subject.to_liquid["sitemap"]).to be_falsey
+      end
+
+      it "sets the paths" do
+        expect(subject.to_liquid["permalink"]).to eql(from)
+        expect(subject.to_liquid).to have_key("redirect")
+        expect(subject.to_liquid["redirect"]["from"]).to eql(from)
+        expect(subject.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
+      end
+
+      it "sets the permalink" do
+        expect(subject.to_liquid["permalink"]).to eql(from)
+      end
+
+      it "sets redirect metadata" do
+        expect(subject.to_liquid).to have_key("redirect")
+        expect(subject.to_liquid["redirect"]["from"]).to eql(from)
+        expect(subject.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
+      end
+    end
+
+    context "generating" do
+      before { site.generate }
+      let(:output) { Jekyll::Renderer.new(site, subject, site.site_payload).run }
+
+      it "renders the template" do
+        expect(output).to_not be_nil
+        expect(output.to_s).to_not be_empty
+      end
+
+      it "contains the meta refresh tag" do
+        expect(output).to match("<meta http-equiv=\"refresh\" content=\"0; url=#{site_url}#{to}\">")
+      end
+
+      it "contains the javascript redirect" do
+        expect(output).to match("<script>location=\"#{site_url}#{to}\"</script>")
+      end
+
+      it "contains canonical link in header" do
+        expect(output).to match("<link rel=\"canonical\" href=\"#{site_url}#{to}\">")
+      end
+
+      it "contains the clickable link" do
+        expect(output).to match("<a href=\"#{site_url}#{to}\">Click here if you are not redirected.</a>")
+      end
+    end
+  end
+
+  context "redirecting to" do
     let(:to) { "/bar" }
     let(:doc) { site.documents.first }
     subject(:page) { described_class.redirect_to(doc, to) }
     let(:from) { doc.url }
 
-    it_behaves_like 'a redirect page'
+    it_behaves_like "a redirect page"
 
     context "a relative path" do
       let(:to) { "/bar" }
@@ -115,13 +115,13 @@ describe JekyllRedirectFrom::RedirectPage do
     end
   end
 
-  describe 'redirecting from' do
+  context "redirecting from" do
     let(:from) { "/foo" }
     let(:doc) { site.documents.first }
     subject(:page) { described_class.redirect_from(doc, from) }
     let(:to) { doc.url }
 
-    it_behaves_like 'a redirect page'
+    it_behaves_like "a redirect page"
 
     it "sets liquid data for the page" do
       expect(page.to_liquid["permalink"]).to eql(from)

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -100,8 +100,6 @@ describe JekyllRedirectFrom::RedirectPage do
     let(:from) { "/foo2" }
     let(:to) { "/bar2" }
 
-    before { subject.set_paths(from, to) }
-
     it "sets the paths" do
       expect(subject.to_liquid["permalink"]).to eql(from)
       expect(subject.to_liquid).to have_key("redirect")

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -63,17 +63,16 @@ shared_examples 'a redirect page' do
 end
 
 describe JekyllRedirectFrom::RedirectPage do
-  let(:from) { "/foo" }
-  let(:to) { "/bar" }
   let(:site_url) { site.config["url"] }
-  subject { described_class.from_paths(site, from, to) }
   before { site.read }
 
-  it_behaves_like 'a redirect page'
-
   describe 'redirecting to' do
+    let(:to) { "/bar" }
     let(:doc) { site.documents.first }
-    let(:page) { described_class.redirect_to(doc, to) }
+    subject(:page) { described_class.redirect_to(doc, to) }
+    let(:from) { doc.url }
+
+    it_behaves_like 'a redirect page'
 
     context "a relative path" do
       let(:to) { "/bar" }
@@ -117,8 +116,12 @@ describe JekyllRedirectFrom::RedirectPage do
   end
 
   describe 'redirecting from' do
+    let(:from) { "/foo" }
     let(:doc) { site.documents.first }
-    let(:page) { described_class.redirect_from(doc, from) }
+    subject(:page) { described_class.redirect_from(doc, from) }
+    let(:to) { doc.url }
+
+    it_behaves_like 'a redirect page'
 
     it "sets liquid data for the page" do
       expect(page.to_liquid["permalink"]).to eql(from)

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -6,42 +6,42 @@ describe JekyllRedirectFrom::RedirectPage do
 
   shared_examples "a redirect page" do
     context "being a page" do
-      before { subject.read_yaml(nil, nil, nil) }
+      before { page.read_yaml(nil, nil, nil) }
 
       it "returns no content" do
-        expect(subject.content).to eql("")
+        expect(page.content).to eql("")
       end
 
       it "returns no output" do
-        expect(subject.output).to eql("")
+        expect(page.output).to eql("")
       end
 
       it "sets default data" do
-        expect(subject.to_liquid["layout"]).to eql("redirect")
-        expect(subject.to_liquid["sitemap"]).to be_falsey
+        expect(page.to_liquid["layout"]).to eql("redirect")
+        expect(page.to_liquid["sitemap"]).to be_falsey
       end
 
       it "sets the paths" do
-        expect(subject.to_liquid["permalink"]).to eql(from)
-        expect(subject.to_liquid).to have_key("redirect")
-        expect(subject.to_liquid["redirect"]["from"]).to eql(from)
-        expect(subject.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
+        expect(page.to_liquid["permalink"]).to eql(from)
+        expect(page.to_liquid).to have_key("redirect")
+        expect(page.to_liquid["redirect"]["from"]).to eql(from)
+        expect(page.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
       end
 
       it "sets the permalink" do
-        expect(subject.to_liquid["permalink"]).to eql(from)
+        expect(page.to_liquid["permalink"]).to eql(from)
       end
 
       it "sets redirect metadata" do
-        expect(subject.to_liquid).to have_key("redirect")
-        expect(subject.to_liquid["redirect"]["from"]).to eql(from)
-        expect(subject.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
+        expect(page.to_liquid).to have_key("redirect")
+        expect(page.to_liquid["redirect"]["from"]).to eql(from)
+        expect(page.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
       end
     end
 
     context "generating" do
       before { site.generate }
-      let(:output) { Jekyll::Renderer.new(site, subject, site.site_payload).run }
+      let(:output) { Jekyll::Renderer.new(site, page, site.site_payload).run }
 
       it "renders the template" do
         expect(output).to_not be_nil

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -71,6 +71,51 @@ describe JekyllRedirectFrom::RedirectPage do
 
   it_behaves_like 'a redirect page'
 
+  describe 'redirecting to' do
+    let(:doc) { site.documents.first }
+    let(:page) { described_class.redirect_to(doc, to) }
+
+    context "a relative path" do
+      let(:to) { "/bar" }
+
+      it "redirects" do
+        expect(page.to_liquid["permalink"]).to eql("/2014/01/03/redirect-me-plz.html")
+        expect(page.to_liquid).to have_key("redirect")
+        expect(page.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
+        expect(page.to_liquid["redirect"]["from"]).to eql("/2014/01/03/redirect-me-plz.html")
+      end
+
+      context "with no leading slash" do
+        let(:to) { "bar" }
+
+        it "redirects" do
+          expect(page.to_liquid).to have_key("redirect")
+          expect(page.to_liquid["redirect"]["to"]).to eql("#{site_url}/#{to}")
+        end
+      end
+
+      context "with a trailing slash" do
+        let(:to) { "/bar/" }
+
+        it "redirects" do
+          expect(page.to_liquid).to have_key("redirect")
+          expect(page.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
+        end
+      end
+    end
+
+    context "an absolute URL" do
+      let(:to) { "https://foo.invalid" }
+
+      it "redirects" do
+        expect(page.to_liquid["permalink"]).to eql("/2014/01/03/redirect-me-plz.html")
+        expect(page.to_liquid).to have_key("redirect")
+        expect(page.to_liquid["redirect"]["to"]).to eql("https://foo.invalid")
+        expect(page.to_liquid["redirect"]["from"]).to eql("/2014/01/03/redirect-me-plz.html")
+      end
+    end
+  end
+
   context "creating a page from paths" do
 
     context "with a document" do
@@ -89,47 +134,6 @@ describe JekyllRedirectFrom::RedirectPage do
       end
 
       context "redirect to" do
-        let(:page) { described_class.redirect_to(doc, to) }
-
-        context "redirecting to a path" do
-          let(:to) { "/bar" }
-
-          it "redirects" do
-            expect(page.to_liquid["permalink"]).to eql("/2014/01/03/redirect-me-plz.html")
-            expect(page.to_liquid).to have_key("redirect")
-            expect(page.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
-            expect(page.to_liquid["redirect"]["from"]).to eql("/2014/01/03/redirect-me-plz.html")
-          end
-
-          context "with no leading slash" do
-            let(:to) { "bar" }
-
-            it "redirects" do
-              expect(page.to_liquid).to have_key("redirect")
-              expect(page.to_liquid["redirect"]["to"]).to eql("#{site_url}/#{to}")
-            end
-          end
-
-          context "with a trailing slash" do
-            let(:to) { "/bar/" }
-
-            it "redirects" do
-              expect(page.to_liquid).to have_key("redirect")
-              expect(page.to_liquid["redirect"]["to"]).to eql("#{site_url}#{to}")
-            end
-          end
-        end
-
-        context "redirecting to a URL" do
-          let(:to) { "https://foo.invalid" }
-
-          it "redirects" do
-            expect(page.to_liquid["permalink"]).to eql("/2014/01/03/redirect-me-plz.html")
-            expect(page.to_liquid).to have_key("redirect")
-            expect(page.to_liquid["redirect"]["to"]).to eql("https://foo.invalid")
-            expect(page.to_liquid["redirect"]["from"]).to eql("/2014/01/03/redirect-me-plz.html")
-          end
-        end
       end
     end
   end

--- a/spec/jekyll_redirect_from/redirect_page_spec.rb
+++ b/spec/jekyll_redirect_from/redirect_page_spec.rb
@@ -116,35 +116,24 @@ describe JekyllRedirectFrom::RedirectPage do
     end
   end
 
-  context "creating a page from paths" do
+  describe 'redirecting from' do
+    let(:doc) { site.documents.first }
+    let(:page) { described_class.redirect_from(doc, from) }
 
-    context "with a document" do
-      let(:doc) { site.documents.first }
-
-      context "redirect from" do
-        let(:page) { described_class.redirect_from(doc, from) }
-
-        it "creates with redirect_from" do
-          expect(page.to_liquid["permalink"]).to eql(from)
-          expect(page.to_liquid).to have_key("redirect")
-          expect(page.to_liquid["redirect"]["from"]).to eql(from)
-          expected = "http://jekyllrb.com/2014/01/03/redirect-me-plz.html"
-          expect(page.to_liquid["redirect"]["to"]).to eql(expected)
-        end
-      end
-
-      context "redirect to" do
-      end
+    it "sets liquid data for the page" do
+      expect(page.to_liquid["permalink"]).to eql(from)
+      expect(page.to_liquid).to have_key("redirect")
+      expect(page.to_liquid["redirect"]["from"]).to eql(from)
+      expected = "http://jekyllrb.com/2014/01/03/redirect-me-plz.html"
+      expect(page.to_liquid["redirect"]["to"]).to eql(expected)
     end
-  end
 
-  context "redirect from destination" do
     context "when redirect from has no extension" do
       let(:from) { "/foo" }
 
       it "adds .html" do
         expected = File.expand_path "foo.html", site.dest
-        expect(subject.destination("/")).to eql(expected)
+        expect(page.destination("/")).to eql(expected)
       end
     end
 
@@ -153,7 +142,11 @@ describe JekyllRedirectFrom::RedirectPage do
 
       it "knows to add the index.html" do
         expected = File.expand_path "foo/index.html", site.dest
-        expect(subject.destination("/")).to eql(expected)
+        expect(page.destination("/")).to eql(expected)
+      end
+
+      it "uses HTML" do
+        expect(page.output_ext).to eql(".html")
       end
     end
 
@@ -162,7 +155,7 @@ describe JekyllRedirectFrom::RedirectPage do
 
       it "adds .html" do
         expected = File.expand_path "foo.html", site.dest
-        expect(subject.destination("/")).to eql(expected)
+        expect(page.destination("/")).to eql(expected)
       end
     end
 
@@ -171,7 +164,11 @@ describe JekyllRedirectFrom::RedirectPage do
 
       it "doesn't add .html" do
         expected = File.expand_path "foo.htm", site.dest
-        expect(subject.destination("/")).to eql(expected)
+        expect(page.destination("/")).to eql(expected)
+      end
+
+      it "honors the extension" do
+        expect(page.output_ext).to eql(".htm")
       end
     end
 
@@ -180,33 +177,11 @@ describe JekyllRedirectFrom::RedirectPage do
 
       it "adds the slash" do
         expected = File.expand_path "foo.html", site.dest
-        expect(subject.destination("/")).to eql(expected)
+        expect(page.destination("/")).to eql(expected)
       end
-    end
-  end
-
-  context "output extension" do
-    context "with an extension" do
-      let(:from) { "foo.htm" }
-
-      it "honors the extension" do
-        expect(subject.output_ext).to eql(".htm")
-      end
-    end
-
-    context "with a trailing slash" do
-      let(:from) { "foo/" }
 
       it "uses HTML" do
-        expect(subject.output_ext).to eql(".html")
-      end
-    end
-
-    context "with no slash" do
-      let(:from) { "foo" }
-
-      it "uses HTML" do
-        expect(subject.output_ext).to eql(".html")
+        expect(page.output_ext).to eql(".html")
       end
     end
   end


### PR DESCRIPTION
I was planning to take a crack at #214 and realized that the specs for `RedirectPage` could do with some refactoring before actually implementing the fix for it. Would like to get the refactor merged before moving on to the actual fix.

At a high level the refactor does the following:
* Extract common code into an rspec `shared_examples` block.
* Stop using `RedirectPage.from_paths` in the spec. ~and makes it private~.
* Only use `RedirectPage.redirect_from` and `RedirectPage.redirect_to` in the spec.
* Split the specs into two high level contexts for each of the two public class methods.
