### PR TITLE
prevent installation of jekyll 3.9 on CI for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
   - &latest_ruby 2.7
   - 2.5
 env:
-  - JEKYLL_VERSION="~> 3.8"
+  - JEKYLL_VERSION="~> 3.8.0"
 matrix:
   include:
     - # GitHub Pages


### PR DESCRIPTION
Sets `JEKYLL_VERSION='~> 3.8.0'` to ensure that jekyll `3.9` does not cause CI breakage.
This is a temporary workaround until we can figure what to do about `kramdown-parser-gfm`.