### PR TITLE
Use head/body tags in redirection markup

### DIFF
--- a/lib/jekyll-redirect-from/redirect.html
+++ b/lib/jekyll-redirect-from/redirect.html
@@ -1,11 +1,15 @@
 <!DOCTYPE html>
 <html lang="en-US">
+<head>
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
   <link rel="canonical" href="{{ page.redirect.to }}">
   <script>location="{{ page.redirect.to }}"</script>
   <meta http-equiv="refresh" content="0; url={{ page.redirect.to }}">
   <meta name="robots" content="noindex">
+</head>
+<body>
   <h1>Redirecting&hellip;</h1>
   <a href="{{ page.redirect.to }}">Click here if you are not redirected.</a>
+</body>
 </html>


### PR DESCRIPTION
Running a Netlify plugin using [html-validate](https://html-validate.org/) fires warnings against redirect pages.