### PR TITLE
Clean up gemspec

### DIFF
--- a/jekyll-redirect-from.gemspec
+++ b/jekyll-redirect-from.gemspec
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "English"
 require_relative "lib/jekyll-redirect-from/version"
 
 Gem::Specification.new do |spec|
@@ -8,15 +7,11 @@ Gem::Specification.new do |spec|
   spec.version       = JekyllRedirectFrom::VERSION
   spec.authors       = ["Parker Moore"]
   spec.email         = ["parkrmoore@gmail.com"]
-  spec.summary       = "Seamlessly specify multiple redirection URLs " \
-                       "for your pages and posts"
+  spec.summary       = "Seamlessly specify multiple redirection URLs for your pages and posts"
   spec.homepage      = "https://github.com/jekyll/jekyll-redirect-from"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-
-  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
+  spec.files         = `git ls-files lib`.split("\n").concat(%w(LICENSE.txt README.md History.markdown))
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.5.0"


### PR DESCRIPTION
- Remove redundant specification `executables`.
- Replace use of `$INPUT_RECORD_SEPARATOR` from stdlib `English` with `"\n"`.
- Bundle only lib_files, License, README and History.markdown in the gem (*instead of [everything in the repository](https://github.com/jekyll/jekyll-redirect-from/runs/3690890948?check_suite_focus=true#step:7:4).*)