### PR TITLE
Remove spaces from filenames

### DIFF
--- a/spec/fixtures/tags/how_we_work.md
+++ b/spec/fixtures/tags/how_we_work.md
@@ -1,4 +1,4 @@
 ---
 redirect_to: "/tags/how-we-work/"
-permalink: "/tags/how we work/"
+permalink: "/tags/how_we_work/"
 ---


### PR DESCRIPTION
Some tools, like Bazel, don't play well with spaces in filenames. Stick to file convention to use underscores or dashes to separate words in filenames.