### PR TITLE
Use site or page language

### DIFF
--- a/lib/jekyll-redirect-from/redirect.html
+++ b/lib/jekyll-redirect-from/redirect.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en-US">
+<html lang="{{ page.lang | default: site.lang | default: 'en' }}">
   <meta charset="utf-8">
   <title>Redirecting&hellip;</title>
   <link rel="canonical" href="{{ page.redirect.to }}">


### PR DESCRIPTION
Rather than hard-code to use en-US, pick up the language tag from the page or site in the same way as the minima layout.